### PR TITLE
Pass upper level param

### DIFF
--- a/prow/daily-e2e-rbac-auth.sh
+++ b/prow/daily-e2e-rbac-auth.sh
@@ -26,4 +26,4 @@ set -u
 # Print commands
 set -x
 
-./prow/daily-release-qualification.sh --auth_enable
+./prow/daily-release-qualification.sh --auth_enable "$@"

--- a/prow/daily-e2e-rbac-no_auth.sh
+++ b/prow/daily-e2e-rbac-no_auth.sh
@@ -26,4 +26,4 @@ set -u
 # Print commands
 set -x
 
-./prow/daily-release-qualification.sh
+./prow/daily-release-qualification.sh "$@"


### PR DESCRIPTION
We need to pass "default_proxy" to e2e framework.

In https://storage.googleapis.com/istio-prow/pull/istio-releases_daily-release/324/daily-e2e-rbac-auth-default/214/build-log.txt

```
W0126 02:06:47.739] + ./prow/daily-e2e-rbac-auth.sh --default_proxy
W0126 02:06:47.740] + ./prow/daily-release-qualification.sh --auth_enable
```
This believed hides istioctl issue in `rbac-auth-default` and `rbac-no_auth-default`. Luckily it's being caught in `cluster-wide-default`

https://github.com/istio-releases/daily-release/pull/324