### PR TITLE
Use SHA references in PROXY_SKEW_TARGETS

### DIFF
--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -14,6 +14,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+# Artifacts of proxy are named using SHA
+# Long term solution may be some translation between release tag and SHA
 export PROXY_SKEW_TARGETS=(
-	0.5.1
+	8f532a4a7af2bdb09b09ef49906538ee25bd578d  # 0.5.1
 )


### PR DESCRIPTION
Louis discovered that istio-releases/daily-release/prow/lib.sh uses a release-tag rather than a SHA, causing the build script to download a proxy build of the form `https://storage.googleapis.com/istio-build/proxy/envoy-$PROXY_TAG.tar.gz`, but all proxy artifacts are built using SHA as names. Immediate fix is to update prow/lib.sh to reference using SHA.

fixes https://github.com/istio/istio/issues/4126

/cc @louiscryan