### PR TITLE
perf: print release-url in daily-perf tests

### DIFF
--- a/prow/daily-perf-tests.sh
+++ b/prow/daily-perf-tests.sh
@@ -49,6 +49,7 @@ function get_istio_code() {
   FILE_LOG="$(mktemp /tmp/XXXXX.boskos.log)"
 
 
+  echo "Using release url: ${ISTIO_REL_URL}"
   ISTIO_SHA=`curl $ISTIO_REL_URL/manifest.xml | grep -E "name=\"(([a-z]|-)*)/istio\"" | cut -f 6 -d \"`
   [[ -z "${ISTIO_SHA}"  ]] && echo "error need to test with specific SHA" && exit 1
 


### PR DESCRIPTION
Signed-off-by: Christopher M. Luciano <cmluciano@us.ibm.com>

Trying to debug what daily build the failing perf tests are using